### PR TITLE
Fix sample Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bin/python exampleapp.py
+web: python exampleapp.py


### PR DESCRIPTION
Commands should not explicitly use `bin/python`, but just `python`, letting PATH (or an activated virtualenv) do its trick. We are normalizing our python docs and buildpack around this.
