### PR TITLE
Fix for issue #7 - TypeError: Incorrect padding; https://github.com/heroku/facebook-template-python/issues/7

### DIFF
--- a/exampleapp.py
+++ b/exampleapp.py
@@ -131,7 +131,8 @@ def get_token():
         encoded_data = c.split('.', 2)
 
         sig = encoded_data[0]
-        data = json.loads(urlsafe_b64decode(str(encoded_data[1])))
+        data = json.loads(urlsafe_b64decode(str(encoded_data[1]) +
+            (64-len(encoded_data[1])%64)*"="))
 
         if not data['algorithm'].upper() == 'HMAC-SHA256':
             raise ValueError('unknown algorithm {0}'.format(data['algorithm']))


### PR DESCRIPTION
Modified the line that performs base 64 encoding to work correctly.
