### PR TITLE
Login permissions are no longer hard-coded

### DIFF
--- a/exampleapp.py
+++ b/exampleapp.py
@@ -201,7 +201,8 @@ def index():
             me=me, POST_TO_WALL=POST_TO_WALL, SEND_TO=SEND_TO, url=url,
             channel_url=channel_url, name=FB_APP_NAME)
     else:
-        return render_template('login.html', app_id=FB_APP_ID, token=access_token, url=request.url, channel_url=channel_url, name=FB_APP_NAME)
+        permission_list = ",".join(app.config['FBAPI_SCOPE'])
+        return render_template('login.html', app_id=FB_APP_ID, token=access_token, url=request.url, channel_url=channel_url, name=FB_APP_NAME, permission_list=permission_list)
 
 @app.route('/channel.html', methods=['GET', 'POST'])
 def get_channel():

--- a/templates/login.html
+++ b/templates/login.html
@@ -6,7 +6,7 @@
   <div id="fb-root"></div>
   <h1>Welcome</h1>
   <div id="login-flow">
-    <fb:login-button perms="email,offline_access" show-faces="true"></fb:login-button>
+    <fb:login-button perms="{{ permission_list }}" show-faces="true"></fb:login-button>
   </div>
 
 {% endblock %}


### PR DESCRIPTION
Hi. I noticed in your template that app permissions can be set in conf.py but are then hard-coded in login.html. This makes it hard to change app permissions. I've made a small change which puts the permissions from conf.py in login.html.

Please note that I am new to the Facebook API. But this change works for me. Also, this is my first pull request. Hope I did it right ;)
